### PR TITLE
Keep legitime spaces inside data

### DIFF
--- a/auth-source-pass.el
+++ b/auth-source-pass.el
@@ -167,15 +167,13 @@ The secret is the first line of CONTENTS."
 (defun auth-source-pass--parse-data (contents)
   "Parse the password-store data in the string CONTENTS and return an alist.
 CONTENTS is the contents of a password-store formatted file."
-  (let ((lines (split-string contents "\n" t "[ \t]+")))
+  (let ((lines (cdr (split-string contents "\n" t "[ \t]+"))))
     (seq-remove #'null
                 (mapcar (lambda (line)
-                          (let ((pair (mapcar (lambda (s) (string-trim s))
-                                              (split-string line ":"))))
-                            (when (> (length pair) 1)
-                              (cons (car pair)
-                                    (mapconcat #'identity (cdr pair) ":")))))
-                        (cdr lines)))))
+                          (when-let ((pos (seq-position line ?:)))
+                            (cons (string-trim (substring line 0 pos))
+                                  (string-trim (substring line (1+ pos))))))
+                        lines))))
 
 (defun auth-source-pass--do-debug (&rest msg)
   "Call `auth-source-do-debug` with MSG and a prefix."

--- a/test/auth-source-pass-tests.el
+++ b/test/auth-source-pass-tests.el
@@ -49,6 +49,12 @@
                    '(("key1" . "val1")
                      ("key2" . "val2"))))))
 
+(ert-deftest auth-source-pass-parse-with-colons-in-data ()
+  (let ((content "pass\n--\nkey1 :val1\nkey2: please: keep my space after colon\n\n"))
+    (should (equal (auth-source-pass--parse-data content)
+                   '(("key1" . "val1")
+                     ("key2" . "please: keep my space after colon"))))))
+
 (defvar auth-source-pass--debug-log nil
   "Contains a list of all messages passed to `auth-source-do-debug`.")
 


### PR DESCRIPTION
## Non-coders description
In order to beat Mr. Han, Bruce must remember **exactly** all his master's advice (1).
As Bruce has a bad memory and the messages are quite long, he has decided to store them as `pass` fields.

Then, he will recover the messages with `auth-source-pass` 5 min. before his fight with Mr. Han.
As said before, Bruce can only win if he follows his master's advice exactly:

> including inner spaces.

Let's help him to win! (2)

References:
[1] https://www.youtube.com/watch?v=io87SbDOKqM
[2] https://www.youtube.com/watch?v=RBnIbqW6ZhM

## Lisper's description

Users should be able to store a field as follows:
message: remember: Destroy the image and you will break the enemy

and later, recover the message untouched, i.e.:
"remember: Destroy the image and you will break the enemy"

* auth-source-pass.el (auth-source-pass--parse-data):
Preserve inner spaces at data.

* test/auth-source-pass-tests.el
(auth-source-pass-parse-with-colons-in-data): Add test.